### PR TITLE
Fixed decap version to one, that is not broken

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@astropub/md": "^1.0.0",
         "astro": "^4.16.18",
         "astro-heroicons": "^2.1.5-1",
-        "decap-cms-app": "^3.3.3",
+        "decap-cms-app": "3.3.3",
         "github-markdown-css": "^5.7.0",
         "joi": "^17.13.3",
         "react": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@astropub/md": "^1.0.0",
     "astro": "^4.16.18",
     "astro-heroicons": "^2.1.5-1",
-    "decap-cms-app": "^3.3.3",
+    "decap-cms-app": "3.3.3",
     "github-markdown-css": "^5.7.0",
     "joi": "^17.13.3",
     "react": "^18.3.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Locked a key dependency to version 3.3.3, ensuring reliable and consistent performance without automatic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->