### PR TITLE
Added auth for tally

### DIFF
--- a/backend/__tests__/tally.test.ts
+++ b/backend/__tests__/tally.test.ts
@@ -8,8 +8,7 @@ async function makeSignature(secret: string, body: string): Promise<string> {
     { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
   )
   const buf = await crypto.subtle.sign('HMAC', key, enc.encode(body))
-  return Array.from(new Uint8Array(buf))
-    .map(b => b.toString(16).padStart(2, '0')).join('')
+  return btoa(String.fromCharCode(...new Uint8Array(buf)))
 }
 
 // Mock the Microsoft Graph Client

--- a/backend/__tests__/tally.test.ts
+++ b/backend/__tests__/tally.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { processTallyWebhook } from '../src/lib/webhook'
+import { processTallyWebhook, verifyTallySignature } from '../src/lib/webhook'
+
+async function makeSignature(secret: string, body: string): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw', enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+  )
+  const buf = await crypto.subtle.sign('HMAC', key, enc.encode(body))
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0')).join('')
+}
 
 // Mock the Microsoft Graph Client
 vi.mock('@microsoft/microsoft-graph-client', () => ({
@@ -19,6 +30,39 @@ vi.mock('@azure/identity', () => ({
 }))
 
 import { Client } from '@microsoft/microsoft-graph-client'
+
+describe('verifyTallySignature', () => {
+  const secret = 'test-signing-secret'
+  const body = '{"data":{"fields":[]}}'
+
+  it('returns true for a valid signature', async () => {
+    const sig = await makeSignature(secret, body)
+    expect(await verifyTallySignature(body, secret, sig)).toBe(true)
+  })
+
+  it('returns false for a tampered body', async () => {
+    const sig = await makeSignature(secret, body)
+    expect(await verifyTallySignature('{"data":{"fields":[1]}}', secret, sig)).toBe(false)
+  })
+
+  it('returns false for a wrong secret', async () => {
+    const sig = await makeSignature('other-secret', body)
+    expect(await verifyTallySignature(body, secret, sig)).toBe(false)
+  })
+
+  it('returns false for a null signature', async () => {
+    expect(await verifyTallySignature(body, secret, null)).toBe(false)
+  })
+
+  it('returns false for an empty signature', async () => {
+    expect(await verifyTallySignature(body, secret, '')).toBe(false)
+  })
+
+  it('returns false for an empty signing secret', async () => {
+    const sig = await makeSignature(secret, body)
+    expect(await verifyTallySignature(body, '', sig)).toBe(false)
+  })
+})
 
 describe('Tally Webhook Handler', () => {
   beforeEach(() => {

--- a/backend/src/lib/webhook.ts
+++ b/backend/src/lib/webhook.ts
@@ -32,6 +32,31 @@ interface Env {
   SHAREPOINT_LIST_ID: string
 }
 
+export async function verifyTallySignature(
+  rawBody: string,
+  signingSecret: string,
+  receivedSignature: string | null
+): Promise<boolean> {
+  if (!signingSecret || !receivedSignature) return false
+
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw', enc.encode(signingSecret),
+    { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+  )
+  const buf = await crypto.subtle.sign('HMAC', key, enc.encode(rawBody))
+  const expected = Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0')).join('')
+
+  // Constant-time comparison
+  if (expected.length !== receivedSignature.length) return false
+  let diff = 0
+  for (let i = 0; i < expected.length; i++) {
+    diff |= expected.charCodeAt(i) ^ receivedSignature.charCodeAt(i)
+  }
+  return diff === 0
+}
+
 export async function processTallyWebhook(payload: unknown, env: Env): Promise<{ success: boolean; message: string }> {
   // Validate payload
   const validation = WebhookPayloadSchema.safeParse(payload)

--- a/backend/src/lib/webhook.ts
+++ b/backend/src/lib/webhook.ts
@@ -45,8 +45,7 @@ export async function verifyTallySignature(
     { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
   )
   const buf = await crypto.subtle.sign('HMAC', key, enc.encode(rawBody))
-  const expected = Array.from(new Uint8Array(buf))
-    .map(b => b.toString(16).padStart(2, '0')).join('')
+  const expected = btoa(String.fromCharCode(...new Uint8Array(buf)))
 
   // Constant-time comparison
   if (expected.length !== receivedSignature.length) return false

--- a/backend/src/pages/api/tally-character.ts
+++ b/backend/src/pages/api/tally-character.ts
@@ -1,9 +1,22 @@
 import type { APIRoute } from 'astro'
-import { processTallyWebhook } from '../../lib/webhook'
+import { processTallyWebhook, verifyTallySignature } from '../../lib/webhook'
 
 export const POST = (async ({ request }) => {
   try {
-    const payload = await request.json()
+    const rawBody = await request.text()
+
+    if (import.meta.env.MODE !== 'development') {
+      const valid = await verifyTallySignature(
+        rawBody,
+        import.meta.env.TALLY_SIGNING_SECRET ?? '',
+        request.headers.get('tally-signature')
+      )
+      if (!valid) {
+        return new Response('Unauthorized', { status: 401 })
+      }
+    }
+
+    const payload = JSON.parse(rawBody)
     const result = await processTallyWebhook(payload, {
       SHAREPOINT_TENANT: import.meta.env.SHAREPOINT_TENANT,
       SHAREPOINT_CLIENT_ID: import.meta.env.SHAREPOINT_CLIENT_ID,

--- a/backend/src/pages/api/tally-group.ts
+++ b/backend/src/pages/api/tally-group.ts
@@ -1,9 +1,22 @@
 import type { APIRoute } from 'astro'
-import { processTallyWebhook } from '../../lib/webhook'
+import { processTallyWebhook, verifyTallySignature } from '../../lib/webhook'
 
 export const POST = (async ({ request }) => {
   try {
-    const payload = await request.json()
+    const rawBody = await request.text()
+
+    if (import.meta.env.MODE !== 'development') {
+      const valid = await verifyTallySignature(
+        rawBody,
+        import.meta.env.TALLY_SIGNING_SECRET ?? '',
+        request.headers.get('tally-signature')
+      )
+      if (!valid) {
+        return new Response('Unauthorized', { status: 401 })
+      }
+    }
+
+    const payload = JSON.parse(rawBody)
     const result = await processTallyWebhook(payload, {
       SHAREPOINT_TENANT: import.meta.env.SHAREPOINT_TENANT,
       SHAREPOINT_CLIENT_ID: import.meta.env.SHAREPOINT_CLIENT_ID,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tally webhooks are now authenticated in non-development environments; invalid signatures will be rejected with 401 Unauthorized.

* **Tests**
  * Added end-to-end tests covering webhook signature validation: valid signatures, tampered payloads, wrong secrets, and missing/empty signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->