### PR TITLE
Removed kids game from larp page

### DIFF
--- a/frontend/src/pages/larp-event.astro
+++ b/frontend/src/pages/larp-event.astro
@@ -24,6 +24,5 @@ const event = eventColection[0].data
     <StoryInfo eventTitle={event.title} />
     <TicketRegistration />
     <RegistrationSteps />
-    <ChildrenGame />
   </div>
 </Layout>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed a feature from the LARP event page. Users will no longer see this previously displayed content section on the event page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->